### PR TITLE
pass current status into query

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function createFeathersConnector (options) {
 
       var queryDescriptors = query
       if (isFunction(queryDescriptors)) {
-        queryDescriptors = query(props)
+        queryDescriptors = query(props, getStatus(props))
       }
       if (!isArray(queryDescriptors)) {
         queryDescriptors = [queryDescriptors]


### PR DESCRIPTION
```
query(props, status)
```

because sometimes you need to know when a request has already been made before you do another request. soo hacky, very much looking forward to #8