### PR TITLE
add check for if query property is required

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ const hasProperties = curry((propertyTypes, object) => {
         type,
         required = false
       } = propertyType
+      if (!required) return true
       const objectValue = object[propertyName]
       const isType = type(objectValue)
       return isType
@@ -309,7 +310,7 @@ function createReduxConnector (options) {
 
   const reduxConnector = connectRedux(
     function mapStateToProps (state, props) {
-      // use the original props passed into the top-level 
+      // use the original props passed into the top-level
       const selected = selector(state, props.ownProps)
       // use react state handlers
       const querys = getQuerys(state, props)
@@ -405,4 +406,3 @@ function createFeathersConnector (options) {
 
   return feathersConnector
 }
-

--- a/test/index.js
+++ b/test/index.js
@@ -5,3 +5,20 @@ import { connect } from '../'
 test('feathers-action-react', function (t) {
   t.is(typeof connect, 'function', 'connect is a function')
 })
+
+test('options.query can be a single query object', function (t) {
+  const result = connect({
+    selector: () => null,
+    actions: {
+      dogs: {
+        test: () => null
+      }
+    },
+    query: {
+      service: 'dogs'
+    }
+  })
+
+  // TODO: IK: not really a sufficient test
+  t.is(typeof result, 'function', 'result of connect is a function')
+})


### PR DESCRIPTION
currently `connect` throws if `options.query` is a single object (rather than an array) and that object is missing any of the properties (name, service, params, id, dependencies)

this adds a check for if the property is actually required - only 'service' should be

N.B. there's also a separate but related bug i think in that if you currently pass in an array of query objects for `options.query`, without all the properties specified, `connect` doesn't throw... i.e. the array of queries is not being asserted correctly. brain too tired to work on it more tonight tho